### PR TITLE
fix(KFLUXBUGS-1117): use FindAllStringSubmatch() to get ALL matches

### DIFF
--- a/issue_comment.go
+++ b/issue_comment.go
@@ -84,10 +84,12 @@ func (h *PRCommentHandler) Handle(ctx context.Context, eventType, deliveryID str
 	}
 
 	// extract the Prow job's URL
-	prowJobURL, err := extractProwJobURLFromCommentBody(logger, body)
+	prowJobURL, err := extractProwJobURLFromCommentBody(body)
 	if err != nil {
 		return fmt.Errorf("unable to extract Prow job's URL from the PR comment's body: %+v", err)
 	}
+
+	logger.Debug().Msgf("Prow Job's URL: %s", prowJobURL)
 
 	cfg := prow.ScannerConfig{
 		ProwJobURL:     prowJobURL,
@@ -130,26 +132,19 @@ func (h *PRCommentHandler) Handle(ctx context.Context, eventType, deliveryID str
 
 // extractProwJobURLFromCommentBody extracts the
 // Prow job's URL from the given PR comment's body
-func extractProwJobURLFromCommentBody(logger zerolog.Logger, commentBody string) (string, error) {
-	matchNotFoundError := fmt.Errorf("regex string %s found no matches for the comment body: %s", regexToFetchProwURL, commentBody)
-	var prowJobURL string
-
+func extractProwJobURLFromCommentBody(commentBody string) (string, error) {
 	r, _ := regexp.Compile(regexToFetchProwURL)
-	sliceOfMatchingString := r.FindStringSubmatch(commentBody)
-	if sliceOfMatchingString == nil {
-		return "", matchNotFoundError
-	}
-	for _, match := range sliceOfMatchingString {
-		if !strings.Contains(match, "images") && !strings.HasSuffix(match, ")") {
-			prowJobURL = match
+	sliceOfMatchingString := r.FindAllStringSubmatch(commentBody, -1)
+
+	for _, matchesAndGroups := range sliceOfMatchingString {
+		for _, subsStr := range matchesAndGroups {
+			if !strings.Contains(subsStr, "images") && !strings.HasSuffix(subsStr, ")") {
+				return subsStr, nil
+			}
 		}
 	}
-	if prowJobURL == "" {
-		return "", matchNotFoundError
-	}
-	logger.Debug().Msgf("Prow Job's URL: %s", prowJobURL)
 
-	return prowJobURL, nil
+	return "", fmt.Errorf("regex string %s found no matches for the comment body: %s", regexToFetchProwURL, commentBody)
 }
 
 // getTestSuitesFromXMLFile returns all the JUnitTestSuites


### PR DESCRIPTION
* Currently, the `FindStringSubmatch()` returns the first Match and its Groups, ignoring the other matches.
* This works fine if the first match is what we're interested in (the e2e test job's url), but regex won't match anything if it's the second match.
* This commit instead uses `FindAllStringSubmatch()` to return ALL matches and their groups, and goes through them one by one to ignore the ones with string "images" or ")" in them.