### PR TITLE
Use docker-build pipeline from quay.io/konflux-ci

### DIFF
--- a/.tekton/ci-helper-app-pull-request.yaml
+++ b/.tekton/ci-helper-app-pull-request.yaml
@@ -20,7 +20,7 @@ spec:
     params:
       - name: bundle
         value: >-
-          quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
+          quay.io/konflux-ci/tekton-catalog/pipeline-core-services-docker-build:latest
       - name: name
         value: docker-build
       - name: kind

--- a/.tekton/ci-helper-app-push.yaml
+++ b/.tekton/ci-helper-app-push.yaml
@@ -21,7 +21,7 @@ spec:
     params:
       - name: bundle
         value: >-
-          quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
+          quay.io/konflux-ci/tekton-catalog/pipeline-core-services-docker-build:latest
       - name: name
         value: docker-build
       - name: kind


### PR DESCRIPTION
STONEBLD-2720

The pipeline bundles in quay.io/redhat-appstudio-tekton-catalog are
deprecated, they will no longer receive updates.

Get the bundle from quay.io/konflux-ci/tekton-catalog instead.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
